### PR TITLE
Revert "otasigcheck: Go back to the key-rewrite check."

### DIFF
--- a/tools/releasetools/edify_generator.py
+++ b/tools/releasetools/edify_generator.py
@@ -167,9 +167,8 @@ class EdifyGenerator(object):
         self.script.append('package_extract_file("system/bin/otasigcheck.sh", "/tmp/otasigcheck.sh");')
         self.script.append('package_extract_file("META-INF/org/cyanogenmod/releasekey", "/tmp/releasekey");')
         self.script.append('set_metadata("/tmp/otasigcheck.sh", "uid", 0, "gid", 0, "mode", 0755);')
-        self.script.append('run_program("/tmp/otasigcheck.sh");')
-        ## The script changes the key value when it fails, check for "INVALID"
-        self.script.append('sha1_check(read_file("/tmp/releasekey"),"7241e92725436afc79389d4fc2333a2aa8c20230") && abort("Can\'t install this package on top of incompatible data. Please try another package or run a factory reset");')
+        # Exit code 124 == abort. run_program returns raw, so left-shift 8bit
+        self.script.append('run_program("/tmp/otasigcheck.sh") != "31744" || abort("Can\'t install this package on top of incompatible data. Please try another package or run a factory reset");')
 
   def ShowProgress(self, frac, dur):
     """Update the progress bar, advancing it over 'frac' over the next


### PR DESCRIPTION
sigcheck now returns an explicit abort code

This reverts commit bab150d79c7b9b1f233fc3592b69a42f0b38fbd8.

Change-Id: I2b5860ea427a4db7e29b55cc632b92c6e2910494
