### PR TITLE
recovery: Properly populate recovery/root on Darwin

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -915,7 +915,7 @@ $(recovery_ramdisk): $(MKBOOTFS) $(MINIGZIP) $(RECOVERYIMAGE_EXTRA_DEPS) \
 	$(hide) mkdir -p $(TARGET_RECOVERY_OUT)
 	$(hide) mkdir -p $(TARGET_RECOVERY_ROOT_OUT)/etc $(TARGET_RECOVERY_ROOT_OUT)/tmp
 	@echo -e ${CL_CYN}"Copying baseline ramdisk..."${CL_RST}
-	$(hide) cp -R $(TARGET_ROOT_OUT)/ $(TARGET_RECOVERY_OUT)
+	$(hide) (cd $(PRODUCT_OUT) && tar -cf - $(TARGET_COPY_OUT_ROOT) | (cd $(TARGET_RECOVERY_OUT) && tar -xf -))
 	@echo -e ${CL_CYN}"Modifying ramdisk contents..."${CL_RST}
 	$(hide) rm -f $(TARGET_RECOVERY_ROOT_OUT)/init*.rc
 	$(hide) cp -f $(recovery_initrc) $(TARGET_RECOVERY_ROOT_OUT)/


### PR DESCRIPTION
`cp -R` is not a frequently used pattern in AOSP and has
interoperability problems between BSD cp and GNU cp.

First, the build is not resilient to old builds that did not complete,
since BSD cp does not overwrite by default when used recursively:

 Copying baseline ramdisk...
 cp: symlink: /sbin/healthd: File exists
 make: **\* [/Volumes/code/client/out/target/product/hammerhead/ramdisk-recovery.img] Error 1
 make: **\* Waiting for unfinished jobs....
 ...
 #### make failed to build some targets (06:57 (mm:ss)) ####

Second, BSD cp -R begins the source tree inside the specified source,
resulting in a broken recovery on a brand new build.

 $ uname -s
 Darwin
 $ cp -R root/ recovery
 $ ls recovery/root
 ls: recovery/root: No such file or directory

Change-Id: Ia47ac1ef2c25c7a9a34a587ce71e63dadb2b750c
