### PR TITLE
Enable ADB by default when ro.adb.secure is not 1

### DIFF
--- a/tools/post_process_props.py
+++ b/tools/post_process_props.py
@@ -40,8 +40,9 @@ def mangle_build_prop(prop, overrides):
 # Put the modifications that you need to make into the /default.prop into this
 # function. The prop object has get(name) and put(name,value) methods.
 def mangle_default_prop(prop):
-  # If ro.build.type is eng, then enable adb on USB by default
-  if prop.get("ro.build.type") == "eng":
+  # If ro.adb.secure is not 1, then enable adb on USB by default
+  # (this is for eng builds)
+  if prop.get("ro.adb.secure") != "1":
     val = prop.get("persist.sys.usb.config")
     if val == "":
       val = "adb"


### PR DESCRIPTION
- Property ro.build.type is not part of the default.prop we can't
  use this to decide how to apply adb by default within this function

Change-Id: Ib3eb24c655353966d64c7148d7530244b628ce94
