### PR TITLE
Add support for mediatek platforms

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -101,6 +101,9 @@ include $(BUILD_SYSTEM)/cleanbuild.mk
 # Bring in Qualcomm helper macros
 include $(BUILD_SYSTEM)/qcom_utils.mk
 
+# Bring in Mediatek helper macros too
+include $(BUILD_SYSTEM)/mtk_utils.mk
+
 # Include the google-specific config
 -include vendor/google/build/config.mk
 

--- a/core/mtk_utils.mk
+++ b/core/mtk_utils.mk
@@ -1,0 +1,5 @@
+# Board platforms lists to be used for
+# TARGET_BOARD_PLATFORM specific featurization
+MTK_BOARD_PLATFORMS := mt6592
+MTK_BOARD_PLATFORMS += mt6582
+MTK_BOARD_PLATFORMS += mt6572

--- a/core/tasks/kernel.mk
+++ b/core/tasks/kernel.mk
@@ -140,6 +140,19 @@ else
     endif
 endif
 
+ifeq ($(BOARD_HAS_MTK_HARDWARE),true)
+  ifeq ($(BOARD_USES_MTK_KERNELBUILD),true)
+    include $(CLEAR_VARS)
+    $(shell rm -f $(TARGET_PREBUILT_INT_KERNEL))
+    FULL_KERNEL_BUILD := false
+    PROJECT_NAME := $(TARGET_KERNEL_CONFIG)
+$(TARGET_PREBUILT_INT_KERNEL):
+	cd $(TARGET_KERNEL_SOURCE) && env -i PATH=$(PATH) ./makeMtk -t -o=OUT_DIR=$(OUT_DIR),TARGET_BUILD_VARIANT=$(TARGET_BUILD_VARIANT) $(PROJECT_NAME) r k
+	-cd $(TARGET_KERNEL_SOURCE) && git clean -fd
+
+  endif
+endif
+
 ifeq ($(FULL_KERNEL_BUILD),true)
 
 KERNEL_HEADERS_INSTALL := $(KERNEL_OUT)/usr


### PR DESCRIPTION
This includes optional support for building the kernel with mediatek's
build system, which is usually included with OEM source drops for this
platform. (enabled by BOARD_USES_MTK_KERNELBUILD:=true)

Change-Id: I69fb50aa17d9c171bf8a7c220a0707c4bc570733
